### PR TITLE
Transformer - Patron - Allow international phone numbers

### DIFF
--- a/lib/MMT/Koha/Patron.pm
+++ b/lib/MMT/Koha/Patron.pm
@@ -357,11 +357,11 @@ sub setPhones($s, $o, $b) {
         $log->warn($s->logId().' - '.$msg);
       }
 
-      unless (MMT::Validator::checkIsValidFinnishPhoneNumber($number)) {
+      unless (MMT::Validator::checkIsValidFinnishPhoneNumber($number) || MMT::Validator::checkIsValidInternationalPhoneNumber($number)) {
         my $notification = "Finnish phone number validation failed for number '$number'. opacnote generated.";
         $log->warn($s->logId()." - $notification");
         $s->concatenate($notification => 'borrowernotes');
-        $s->concatenate("Kirjastojärjestelmävaihdon yhteydessä havaittu, että puhelinnumero '$number' ei ole Suomen viestintäministeriön asettaman mallin mukainen. Ota yhteyttä kirjastoosi asian korjaamiseksi." => 'opacnote');
+        $s->concatenate("Kirjastojärjestelmävaihdon yhteydessä on havaittu, että puhelinnumero '$number' on mahdollisesti virheellinen. Ota yhteyttä kirjastoosi asian korjaamiseksi." => 'opacnote');
         next;
       }
       given ($match->{phone_desc}) {

--- a/lib/MMT/Validator.pm
+++ b/lib/MMT/Validator.pm
@@ -70,7 +70,10 @@ sub checkIsAbsolutePath($value) {
 sub checkIsValidFinnishPhoneNumber($value) {
   return $value =~ m/^((90[0-9]{3})?0|\+358\s?)(?!(100|20(0|2(0|[2-3])|9[8-9])|300|600|700|708|75(00[0-3]|(1|2)\d{2}|30[0-2]|32[0-2]|75[0-2]|98[0-2])))(4|50|10[1-9]|20(1|2(1|[4-9])|[3-9])|29|30[1-9]|71|73|75(00[3-9]|30[3-9]|32[3-9]|53[3-9]|83[3-9])|2|3|5|6|8|9|1[3-9])\s?(\d\s?){4,19}\d$/;
 }
-
+sub checkIsValidInternationalPhoneNumber($value) {
+  # regexp pattern form https://www.regextester.com/97440
+  return $value =~ m/^(([+][(]?[0-9]{1,3}[)]?)|([(]?[0-9]{4}[)]?))\s*[)]?[-\s\.]?[(]?[0-9]{1,3}[)]?([-\s\.]?[0-9]{3})([-\s\.]?[0-9]{3,4})\d$/;
+}
 =head2 checkIsValidFinnishSSN
 
  @param {String} SSN


### PR DESCRIPTION
As it is common to have international phone numbers in the patron data, this fix makes phone number validation more lax to allow more variety in phone numbers.