### PR TITLE
Transformer - Patron - Fixes for addPopUpNote

### DIFF
--- a/lib/MMT/Koha/Patron.pm
+++ b/lib/MMT/Koha/Patron.pm
@@ -538,10 +538,11 @@ sub _getActiveOrLatestBarcodeRow($s, $patronGroupsBarcodes) {
   return $patronGroupsBarcodes->[0]; #Extractor should ORDER BY so the newest entry is first.
 }
 
-sub _addPopUpNote($s, $b, $message, $branchcode, $message_date) {
-  die "Trying to add a popup note, but the message is missing" unless ($message);
+sub _addPopUpNote {
+  my ($s, $b, $message, $branchcode, $message_date) = @_;
+  $log->logdie("Trying to add a popup note, but the message is missing") unless ($message);
   $branchcode = $b->{Branchcodes}->translate($s, {}, $b, '_DEFAULT_') unless ($branchcode);
-  die "Trying to add a popup note, but no branchcode given and a _DEFAULT_ branch is missing in Branchcodes translation table" unless ($branchcode);
+  $log->logdie("Trying to add a popup note, but no branchcode given and a _DEFAULT_ branch is missing in Branchcodes translation table") unless ($branchcode);
   $message_date = $b->now() unless ($message_date);
 
   unless ($s->{popup_message}) { # Add a new note


### PR DESCRIPTION
Allow calling _addPopUpNote with only required parameters. Do not die silently when required information is missing.