### PR TITLE
Transformer - Patron - Add popup note when patron statistical group is missing

### DIFF
--- a/lib/MMT/Koha/Patron.pm
+++ b/lib/MMT/Koha/Patron.pm
@@ -412,6 +412,7 @@ sub setStatisticExtAttribute($s, $o, $b) {
     }
   }
   else {
+    $s->_addPopUpNote("Tarkista asiakkaan tilastointiryhmä.","main");
     $log->warn("Patron '".$s->logId()."' has no statistical category.");
   }
 }

--- a/lib/MMT/Koha/Patron.pm
+++ b/lib/MMT/Koha/Patron.pm
@@ -412,8 +412,8 @@ sub setStatisticExtAttribute($s, $o, $b) {
     }
   }
   else {
-    $s->_addPopUpNote("Tarkista asiakkaan tilastointiryhmä.","main");
-    $log->warn("Patron '".$s->logId()."' has no statistical category.");
+    $s->_addPopUpNote($b,"Tarkista asiakkaan tilastointiryhmä.");
+    $log->warn("Patron '".$s->logId()."' has no statistical category. Popup note added.");
   }
 }
 sub setUserid($s, $o, $b) {


### PR DESCRIPTION
For the sake of integrity of patron statistics, it might be useful for library staff to add missing patron statistical group when the patron is visiting the library. Therefore, let's notify staff about missing statistical group.