### PR TITLE
Use bib_master instead of bib_heading to create bib-level suppression

### DIFF
--- a/extractor/VoyagerExtractor/Exp/Strategy/Precision/HAMK.pm
+++ b/extractor/VoyagerExtractor/Exp/Strategy/Precision/HAMK.pm
@@ -68,9 +68,9 @@ our %queries = (
     encoding => "iso-8859-1",
     uniqueKey => -1,
     sql =>
-      "SELECT    bib_heading.bib_id, NULL as mfhd_id, NULL as location_id, \n".
-      "          bib_heading.suppress_in_opac                              \n".
-      "FROM      bib_heading                                               \n".
+      "SELECT    bib_master.bib_id, NULL as mfhd_id, NULL as location_id,  \n".
+      "          bib_master.suppress_in_opac                               \n".
+      "FROM      bib_master                                                \n".
       "WHERE     suppress_in_opac = 'Y'                                    \n".
       "                                                                    \n".
       "UNION                                                               \n".

--- a/extractor/VoyagerExtractor/Exp/Strategy/Precision/Helka.pm
+++ b/extractor/VoyagerExtractor/Exp/Strategy/Precision/Helka.pm
@@ -140,9 +140,9 @@ our %queries = (
     encoding => "iso-8859-1",
     uniqueKey => -1,
     sql =>
-      "SELECT    bib_heading.bib_id, NULL as mfhd_id, NULL as location_id, \n".
-      "          bib_heading.suppress_in_opac                              \n".
-      "FROM      bib_heading                                               \n".
+      "SELECT    bib_master.bib_id, NULL as mfhd_id, NULL as location_id,  \n".
+      "          bib_master.suppress_in_opac                               \n".
+      "FROM      bib_master                                                \n".
       "WHERE     suppress_in_opac = 'Y'                                    \n".
       "                                                                    \n".
       "UNION                                                               \n".


### PR DESCRIPTION
This fixes erroneous suppression mapping, as bib_heading contains information about particular fields to be suppressed and not full records. Full record suppression info is available in bib_master. 