### PR TITLE
Extractor - Use MAX() for selecting the most recent day from the UNIONized last_borrow_date

### DIFF
--- a/extractor/VoyagerExtractor/Exp/Strategy/Precision/HAMK.pm
+++ b/extractor/VoyagerExtractor/Exp/Strategy/Precision/HAMK.pm
@@ -126,7 +126,7 @@ our %queries = (
       #
       # Pick last checkin location normally from the old issues table.
       #
-      "SELECT * FROM                                                                                 \n".
+      "SELECT item_id, max(last_borrow_date) as last_borrow_date FROM                                \n".
       "(                                                                                             \n".
       "SELECT    circ_trans_archive.item_id, max(circ_trans_archive.charge_date) as last_borrow_date \n".
       "FROM      circ_trans_archive                                                                  \n".
@@ -146,6 +146,7 @@ our %queries = (
       "WHERE     hold_recall_items.hold_recall_status = 2    \n". # 2 = 'Pending'. In Voyager-speak this is a hold which is waiting for pickup.
       "                                                      \n".
       ")                                                                                             \n".
+      "GROUP BY item_id                                                                              \n".
       "ORDER BY  item_id ASC                                                                         \n".
       "",
   },

--- a/extractor/VoyagerExtractor/Exp/Strategy/Precision/Helka.pm
+++ b/extractor/VoyagerExtractor/Exp/Strategy/Precision/Helka.pm
@@ -199,7 +199,7 @@ our %queries = (
       #
       # Pick last checkin location normally from the old issues table.
       #
-      "SELECT * FROM                                                                                 \n".
+      "SELECT item_id, max(last_borrow_date) as last_borrow_date FROM                                \n".
       "(                                                                                             \n".
       "SELECT    circ_trans_archive.item_id, max(circ_trans_archive.charge_date) as last_borrow_date \n".
       "FROM      circ_trans_archive                                                                  \n".
@@ -219,6 +219,7 @@ our %queries = (
       "WHERE     hold_recall_items.hold_recall_status = 2    \n". # 2 = 'Pending'. In Voyager-speak this is a hold which is waiting for pickup.
       "                                                      \n".
       ")                                                                                             \n".
+      "GROUP BY item_id                                                                              \n".
       "ORDER BY  item_id ASC                                                                         \n".
       "",
   },


### PR DESCRIPTION
Fixes bug where UNIONized queries creates duplicates. In the import process, the topmost row is being selected, but the most recent day is actually in the duplicated row, which is discarded. This fix forces extractor to select the most recent day from the UNIONIzed queries.