### PR TITLE
Fix INSTALL_PRETTYLIB.sh installer

### DIFF
--- a/INSTALL_PRETTYLIB.sh
+++ b/INSTALL_PRETTYLIB.sh
@@ -52,7 +52,7 @@ mkdir -p $PIPELINE_SCRIPTS             || exit 11
 cp -r config $MMT_HOME/                || exit 11
 cp -r tests $MMT_HOME/                 || exit 11
 cp config/seed.gitignore $MMT_HOME/.gitignore || exit 11
-cp $EXTRACTOR_DIR/PrettyLibExtractor/preprocess.sh $MMT_HOME/preprocess.sh || exit 11
+cp $EXTRACTOR_DIR/PrettyExtractor/preprocess.sh $MMT_HOME/preprocess.sh || exit 11
 cp $EXTRACTOR_DIR/$EXTRACTOR_PIPELINE_SCRIPT $PIPELINE_SCRIPTS/ || exit 12
 cp $LOADER_DIR/$LOADER_PIPELINE_SCRIPT $PIPELINE_SCRIPTS/ || exit 12
 

--- a/INSTALL_PRETTYLIB.sh
+++ b/INSTALL_PRETTYLIB.sh
@@ -33,11 +33,12 @@ test $? != 0 && echo "Couldn't cd to app source code directory '$MMT_CODE', fail
 
 
 echo "Installing Perl dependencies to the program dir '$MMT_CODE'"
-cpanm -L extlib --installdeps .
+echo "$MMT_CODE/transformer"
+cpanm -L $MMT_CODE/transformer/extlib --installdeps $MMT_CODE/transformer
 # Ubuntu 18 fails on one of the dependencies, unless --force is used...
 if [ $? != 0 ]
 then
-  echo "Perl dependencies install failed with error code '$?'. Using force." && cpanm -L extlib --force --installdeps .
+  echo "Perl dependencies install failed with error code '$?'. Using force." && cpanm -L $MMT_CODE/transformer/extlib --force --installdeps $MMT_CODE/transformer
   test $? != 0 && echo "Perl dependencies install failed with error code '$?'. Force did not help." && exit 9
 fi
 

--- a/transformer/cpanfile
+++ b/transformer/cpanfile
@@ -1,5 +1,6 @@
 requires "Log::Log4perl";
 requires "YAML::XS";
+requires "YAML::LibYAML";
 requires "Email::Valid";
 requires "Getopt::OO";
 requires "Carp::Always::Color";
@@ -14,6 +15,3 @@ requires "IPC::Cmd";
 requires "Import::Into";
 requires "Modern::Perl";
 requires "DateTime::Format::MySQL";
-
-libyaml-perl
-libtext-csv-perl


### PR DESCRIPTION
INSTALL_PRETTYLIB.sh was broken in a couple of ways. 

1. `cpanfile` is located under `transformer/`, and the installer script attempts to seek cpanfile from current path `.`. This PR aims to fix installer's paths.
2. `cpanfile` contains Debian package dependencies. AFAIK this is not allowed by `cpanfile` format (nor is cpanm's function either). 

```
libyaml-perl
libtext-csv-perl
```

The installer crashes when you have those two lines in there.
3. Adds `chmod +x INSTALL_PRETTYLIB.sh`.
4. Fixes a broken path `PrettyLibExtractor` -> `PrettyExtractor`