### PR TITLE
Transformer - Load Perl deps from relative path regardless of script exec location

### DIFF
--- a/transformer/transform.pl
+++ b/transformer/transform.pl
@@ -5,7 +5,8 @@
 
 package MAIN;
 #Pragmas
-use lib qw(lib extlib/lib/perl5);
+use FindBin qw($Bin);
+use lib ("$Bin", "$Bin/../lib", "$Bin/extlib/lib/perl5");
 use MMT::Pragmas;
 use MMT::MonkeyPatch;
 


### PR DESCRIPTION
Use `FindBin` so that you can execute transform.pl outside `transformer/` directory without `perl -I` flag.