### PR TITLE
Voyager2Koha/Patron - Fix syntax error

### DIFF
--- a/transformer/MMT/Voyager2Koha/Patron.pm
+++ b/transformer/MMT/Voyager2Koha/Patron.pm
@@ -48,7 +48,7 @@ Flesh out the Koha-borrower -object out of the given
 
 sub build($self, $o, $b) {
   unless ($SSN_EXPORT_FH) {
-    my $outputFilePrefix = split('.', $b->{outputFile})[0];
+    my $outputFilePrefix = (split('.', $b->{outputFile}))[0];
     my $file = MMT::Config::kohaImportDir."/$outputFilePrefix.ssn.csv";
     open($SSN_EXPORT_FH, ">:encoding(UTF-8)", $file) or die("Couldn't open the ssn export file '$file' for writing: $!");
     $SSN_EXPORT_FH->autoflush(1);


### PR DESCRIPTION
Fixing syntax error.

To reproduce, use `cd transformer && perl -I . -c transformer/MMT/Voyager2Koha/Patron.pm`

See the following error
```
syntax error at MMT/Voyager2Koha/Patron.pm line 51, near ")["
Global symbol "$outputFilePrefix" requires explicit package name (did you forget to declare "my $outputFilePrefix"?) at MMT/Voyager2Koha/Patron.pm line 52.
MMT/Voyager2Koha/Patron.pm had compilation errors.
 at MMT/Voyager2Koha/Patron.pm line 561.
```

Apply commit and execute `cd transformer && perl -I . -c transformer/MMT/Voyager2Koha/Patron.pm`

See syntax ok
```
MMT/Voyager2Koha/Patron.pm syntax OK
```