### PR TITLE
PrettyLib - Fix wrong subroutine name

### DIFF
--- a/transformer/MMT/PrettyLib2Koha/Biblio.pm
+++ b/transformer/MMT/PrettyLib2Koha/Biblio.pm
@@ -372,7 +372,7 @@ sub linkClasses($s, $o, $builder) {
                     $field->addSubfield(MMT::MARC::Subfield->new($code, $value));
                   }
                   else {
-                    $sf->value($value);
+                    $sf->content($value);
                   }
                 }
               }


### PR DESCRIPTION
`transform.pl --biblios` would crash into an attempt to call an undefined method `MMT::MARC::Subfield->value()`. I suppose the author wanted to call `MMT::MARC::Subfield->content()` instead.