### PR TITLE
Fix YAML::XS unable to parse a non-quoted dash

### DIFF
--- a/transformer/MMT/AutoConfigurer.pm
+++ b/transformer/MMT/AutoConfigurer.pm
@@ -61,9 +61,11 @@ sub configure($rules) {
 
       my @cols = List::Util::pairmap {$obj->{$a} =~ s/(?:\p{IsCntrl}|\s{2,}|\s+$|^\s+)//gsm; $obj->{$a}} %$obj; # Drop anomalous whitespace in-place and create a list of values for documentation purposes.
 
+      my $kohaValue = $rule->{translationTemplate}->($obj) // 'KONVERSIO';
+      $kohaValue = "'$kohaValue'" if $kohaValue eq '-';
+
       push(@sb, $rule->{sourcePrimaryKeyColumn}->($obj).
-                ': '.
-                ($rule->{translationTemplate}->($obj) // 'KONVERSIO').
+                ": $kohaValue".
                 ' # '.join(", ", @cols)
       );
     }


### PR DESCRIPTION
YAML::XS thinks the following is wrong:

```
key: -
another_key: 123
```

See http://blogs.perl.org/users/brian_d_foy/2010/06/block-sequence-entries-are-not-allowed-in-this-context.html