### PR TITLE
PrettyLib: Validate only non-empty barcodes

### DIFF
--- a/transformer/MMT/PrettyLib2Koha/Item.pm
+++ b/transformer/MMT/PrettyLib2Koha/Item.pm
@@ -114,7 +114,7 @@ sub setBarcode($s, $o, $b) {
     $bc = $o->{BarCode} if $o->{BarCode};
   }
 
-  ($bc, $ok) = MMT::Validator::Barcode::validate(@_, $bc);
+  ($bc, $ok) = MMT::Validator::Barcode::validate(@_, $bc) if defined $bc && length($bc)>0;
   $s->{barcode} = $bc;
 
   my $error;

--- a/transformer/MMT/Validator/Barcode.pm
+++ b/transformer/MMT/Validator/Barcode.pm
@@ -46,7 +46,7 @@ All strategies share the same subroutine interface:
 =cut
 
 our $validatorStrategy; #Cache the validator strategy. Make it accessible from tests so it can be flushed
-sub validate($kohaObject, $voyagerObject, $builder, $phoneCandidate) {
+sub validate($kohaObject, $voyagerObject, $builder, $barcodeCandidate) {
   unless ($validatorStrategy) {
     $validatorStrategy = __PACKAGE__->can('strategy_'.'Code39');
     die "Unknown Barcode validation strategy '".__PACKAGE__.'::strategy_'.'Code39'."'" unless ($validatorStrategy);


### PR DESCRIPTION
Attempting to validate an empty barcode generates an `Use of uninitialized value` warning that spams logs unreadable. Simply skip validating undefined (and empty) barcodes in the `MMT::Validator::Barcode`.