### PR TITLE
Loader - Patron importer fails adding default admin when no categories exist

### DIFF
--- a/loader/KohaLoader/Bulk/PatronImporter.pm
+++ b/loader/KohaLoader/Bulk/PatronImporter.pm
@@ -167,7 +167,11 @@ sub addDefaultAdmin($s, $defaultAdmin) {
   INFO "Adding default admin";
   my $dbh = C4::Context->dbh;
   my $categorycode = $dbh->selectrow_array("SELECT categorycode from categories LIMIT 1") or warn "Failed to get default admin categorycode ".$dbh->errstr(); #Pick any borrower.categorycode
-  $categorycode = 'ADMIN' unless $categorycode;
+  unless ($categorycode) {
+    $dbh->do("INSERT IGNORE INTO categories (categorycode, description) ".
+                              "VALUE ('ADMIN','AUTO-ADMIN')");
+    $categorycode = 'ADMIN';
+  }
   my $branchcode = $dbh->selectrow_array("SELECT branchcode from branches LIMIT 1") or warn "Failed to get default admin branchcode ".$dbh->errstr(); #Pick any borrower.branchcode
   my %defaultAdmin = (
     cardnumber =>   "kalifi",


### PR DESCRIPTION
When PrettyLib instance has no patron categories in Group.csv, loader fails to add default admin provided by the --default-admin switch.