### PR TITLE
Pretty*: Reduce log level for empty barcodes

### DIFF
--- a/transformer/MMT/PrettyLib2Koha/Item.pm
+++ b/transformer/MMT/PrettyLib2Koha/Item.pm
@@ -135,13 +135,13 @@ sub setBarcode($s, $o, $b) {
       MMT::Exception::Delete->throw($msg);
     }
     elsif (MMT::Config::emptyBarcodePolicy() eq 'IGNORE') {
-      $log->error($msg) if ($s->{barcode});
+      $log->info($msg) if ($s->{barcode});
       $s->{barcode} = undef;
       #Ignore
     }
     elsif (MMT::Config::emptyBarcodePolicy() eq 'CREATE') {
       my $newBc = $s->createBarcode();
-      $log->error("$msg Created barcode '$newBc'.");
+      $log->info("$msg Created barcode '$newBc'.");
       $s->{barcode} = $newBc;
     }
   }


### PR DESCRIPTION
These are not errors because we have configured to accept empty barcodes.

Reduce log level to info