### PR TITLE
Execute USEMARCON at transform phase

### DIFF
--- a/config/main.yaml
+++ b/config/main.yaml
@@ -83,6 +83,10 @@ csvInputParams:
     munge_column_names: none
 
 
+# Relative path to USEMARCON INI file in $MMT_CODE/usemarcon directory. Leave empty if you want to skip usemarcon execution.
+# Example: USEMARCON-fi2ma/fi2ma.ini
+usemarconIniFile: ''
+
 ############ PRETTY* -specific configs ################
 
 # Instead of the Item.BarCode use Item.AcqNumIdx to populate koha.items.barcode

--- a/transformer/MMT/Config.pm
+++ b/transformer/MMT/Config.pm
@@ -92,6 +92,9 @@ sub translationTablesDir() {
 sub useHetula() {
   return $config->{useHetula};
 }
+sub usemarconIniFile() {
+  return $ENV{MMT_CODE}.'/usemarcon/'.$config->{usemarconIniFile};
+}
 sub workers() {
   return $config->{workers};
 }

--- a/transformer/MMT/Shell.pm
+++ b/transformer/MMT/Shell.pm
@@ -14,8 +14,8 @@ MMT::Shell - Wrapper to run shell scripts
 
 =cut
 
-sub run($cmd) {
-  my($success, $error_code, $full_buf, $stdout_buf, $stderr_buf) = IPC::Cmd::run(command => $cmd, verbose => 1);
+sub run($cmd, $verbosity=1) {
+  my($success, $error_code, $full_buf, $stdout_buf, $stderr_buf) = IPC::Cmd::run(command => $cmd, verbose => $verbosity);
 
   if ($error_code) {
     $log->logdie(

--- a/transformer/MMT/Usemarcon.pm
+++ b/transformer/MMT/Usemarcon.pm
@@ -1,0 +1,47 @@
+package MMT::Usemarcon;
+
+use MMT::Pragmas;
+
+#External modules
+
+#Local modules
+use MMT::Shell;
+my Log::Log4perl $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+=head1 NAME
+
+MMT::Usemarcon - Runs the USEMARCON tool on your bibliographic records
+
+=cut
+
+=head2 execute
+
+Use usemarcon to do the transformation. Outputs MARC21.
+
+ARGS:
+
+C<$sourceRecordsFile> Input
+
+=cut
+
+sub execute($sourceRecordsFile) {
+  my $usemarconIniFile = MMT::Config::usemarconIniFile();
+  unless ($usemarconIniFile) {
+    return 1;
+  }
+  my $inputMARCFile = $sourceRecordsFile;
+  my $outputMARCFile = $sourceRecordsFile.'.marc21';
+
+  $log->info("Starting USEMARCON script with $usemarconIniFile configuration");
+  my $cmd = $ENV{MMT_CODE} . "/usemarcon/usemarcon $usemarconIniFile $inputMARCFile $outputMARCFile";
+  my ($success, $error_code, $full_buf, $stdout_buf, $stderr_buf) = MMT::Shell::run($cmd, 0);
+  if ($success) {
+    MMT::Shell::run("cp $outputMARCFile $inputMARCFile && rm $outputMARCFile", 0);
+    $log->info("USEMARCON success");
+  } else {
+    $log->error("USEMARCON error (code $error_code): $stderr_buf");
+  }
+  return !$success; # Getopt::OO callback errors if we return something.
+}
+
+return 1;

--- a/transformer/MMT/Voyager2Koha/Biblio.pm
+++ b/transformer/MMT/Voyager2Koha/Biblio.pm
@@ -5,7 +5,6 @@ use MMT::Pragmas;
 #External modules
 
 #Local modules
-use MMT::Shell;
 use MMT::MARC::Regex;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
@@ -205,19 +204,5 @@ sub _linkCreateField($s, $xmlPtr, $b, $sourceFieldCode, $destinationBiblionumber
 
 ###########################################################################################
 ###########################################################################################
-
-=head2 usemarcon
-
-Use usemarcon to do the transformation.
-
-=cut
-
-sub usemarcon() {
-  my $inputMARCFile = MMT::Config::exportsDir()."/biblios.marcxml";
-  my $outputMARCFile = MMT::Config::kohaImportDir()."/biblios.marcxml";
-  my $cmd = "usemarcon/usemarcon usemarcon/rules-hamk/rules.ini $inputMARCFile $outputMARCFile";
-  my ($success, $error_code, $full_buf, $stdout_buf, $stderr_buf) = MMT::Shell::run($cmd);
-  return !$success; # Getopt::OO callback errors if we return something.
-}
 
 return 1;

--- a/transformer/transform.pl
+++ b/transformer/transform.pl
@@ -21,6 +21,7 @@ use MMT::Builder;
 use MMT::Extractor;
 use MMT::Loader;
 use MMT::TBuilder;
+use MMT::Usemarcon;
 use MMT::Voyager2Koha::Biblio;
 
 
@@ -169,6 +170,8 @@ MMT_HOME: ".($ENV{MMT_HOME} || '')."
       }
 
       build($confBase, $conf);
+
+      MMT::Usemarcon::execute($confBase->{outputFile});
     },
   },
 


### PR DESCRIPTION
This PR adds USEMARCON execution to transformer for automatic on-demand record manipulation. Configurable with a new `usemarconIniFile` config (if empty, skips USEMARCON altogether).

Also adds verbosity configuration parameter to MMT::Shell because we don't want to spam logfiles by USEMARCON's massive stdout logging (it's counting all the processed records).